### PR TITLE
FIX: set Core OpenGL profile for OS X compat

### DIFF
--- a/src/gpu/opengl/mod.rs
+++ b/src/gpu/opengl/mod.rs
@@ -47,6 +47,7 @@ impl Renderer {
     pub fn new(sdl_context: &sdl2::Sdl) -> Renderer {
         sdl2::video::gl_set_attribute(GLAttr::GLContextMajorVersion, 3);
         sdl2::video::gl_set_attribute(GLAttr::GLContextMinorVersion, 3);
+        sdl2::video::gl_set_attribute(GLAttr::GLContextProfileMask, 1); // core profile
 
         // XXX Debug context is likely to be slower, we should make
         // that configurable at some point.


### PR DESCRIPTION
this gets me a little closer to running on Yosemite, encountering another panic after this though.

i'm not sure at this point if it is due to using the core profile or what really.

I will post a backtrace in an issue and see if you can help me out.
